### PR TITLE
Fix missing instance ids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "codekanzlei/cake-auth-actions": "1.0.*",
         "codekanzlei/cake-list-filter": "1.2.*",
         "codekanzlei/cake-cktools": "1.2.*",
-        "codekanzlei/cake-frontend-bridge": "1.0.*",
+        "codekanzlei/cake-frontend-bridge": "1.2.*",
         "codekanzlei/cake-attachments": "1.0.*",
         "codekanzlei/cake-notifications": "v2.0.*",
         "codekanzlei/cake-model-history": "2.0.*",

--- a/src/Template/Layout/default.ctp
+++ b/src/Template/Layout/default.ctp
@@ -12,7 +12,7 @@ $this->assign('adminLTETheme', 'skin-blue-light');
             <?= $this->element('Layout/header') ?>
             <?= $this->element('Layout/sidebar') ?>
 
-            <div class="content-wrapper <?php echo $this->FrontendBridge->getMainContentClasses() ?>">
+            <div <?= $this->FrontendBridge->getControllerAttributes(['content-wrapper']) ?>>
                 <?= $this->fetch('contentHeader') ?>
                 <section class="content">
                     <?= $this->Flash->render() ?>


### PR DESCRIPTION
Adapt the default.ctp template to correctly generate instance ids needed for scherersoftware/cake-frontend-bridge