### PR TITLE
Fix php_syntax.sh

### DIFF
--- a/bin/php_syntax.sh
+++ b/bin/php_syntax.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sh -c 'if find . -name "*.php" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi'
-sh -c 'if find . -name "*.ctp" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi'
+if find . -name "*.php" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
+if find . -name "*.ctp" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi


### PR DESCRIPTION
Remove outer sh shell to correctly give exit codes to composer check