### PR TITLE
Further improve php_syntax.sh

### DIFF
--- a/bin/php_syntax.sh
+++ b/bin/php_syntax.sh
@@ -14,21 +14,33 @@ set -o errexit
 
 error=false
 
-while IFS= read -r -d '' file
-do
-    EXTENSION="${file##*.}"
+while test $# -gt 0; do
+    current=$1
+    shift
 
-    if [ "$EXTENSION" == "php" ] || [ "$EXTENSION" == "ctp" ]
-    then
-        RESULTS=`php -l $file`
+    if [ ! -d $current ] && [ ! -f $current ] ; then
+        echo "Invalid directory or file: $current"
+        error=true
 
-        if [ "$RESULTS" != "No syntax errors detected in $file" ]
-        then
-            echo $RESULTS
-            error=true
-        fi
+        continue
     fi
-done <   <(find . -print0)
+
+    while IFS= read -r -d '' file
+    do
+        EXTENSION="${file##*.}"
+
+        if [ "$EXTENSION" == "php" ] || [ "$EXTENSION" == "ctp" ]
+        then
+            RESULTS=`php -l $file`
+
+            if [ "$RESULTS" != "No syntax errors detected in $file" ]
+            then
+                echo $RESULTS
+                error=true
+            fi
+        fi
+    done <   <(find $current -print0)
+done
 
 if [ "$error" = true ] ; then
     exit 1

--- a/bin/php_syntax.sh
+++ b/bin/php_syntax.sh
@@ -1,3 +1,37 @@
 #!/bin/bash
-if find . -name "*.php" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
-if find . -name "*.ctp" ! -path "./vendor/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi
+
+# trace ERR through pipes
+set -o pipefail
+
+# trace ERR through 'time command' and other functions
+set -o errtrace
+
+# set -u : exit the script if you try to use an uninitialised variable
+set -o nounset
+
+# set -e : exit the script if any statement returns a non-true return value
+set -o errexit
+
+error=false
+
+while IFS= read -r -d '' file
+do
+    EXTENSION="${file##*.}"
+
+    if [ "$EXTENSION" == "php" ] || [ "$EXTENSION" == "ctp" ]
+    then
+        RESULTS=`php -l $file`
+
+        if [ "$RESULTS" != "No syntax errors detected in $file" ]
+        then
+            echo $RESULTS
+            error=true
+        fi
+    fi
+done <   <(find . -print0)
+
+if [ "$error" = true ] ; then
+    exit 1
+else
+    exit 0
+fi

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "js-check": "node_modules/.bin/eslint .",
         "js-fix": "node_modules/.bin/eslint . --fix",
         "i18n": "bin/i18n.sh",
-        "php-syntax": "bin/php_syntax.sh",
+        "php-syntax": "bin/php_syntax.sh src/ tests/ index.php",
         "test": "phpunit --colors=always"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Use a complete script with correct error handling and a nice syntax.
This will also print the filename where the php syntax check failed.